### PR TITLE
Update CSS for DuckDuckHack Docs code snippets

### DIFF
--- a/share/css/main.css
+++ b/share/css/main.css
@@ -140,6 +140,12 @@ pre code {
 	font-size: 12px;
 }
 
+.duckduckhack-docs p > code {
+	background: #e1e1e1;
+    padding: 2px 3px;
+    border-radius: 2px;
+}
+
 /* For syntax highlighting in code blocks */
 code > .synComment { color: lightblue; }
 code > .synConstant { color: lightgreen; }

--- a/share/css/main.css
+++ b/share/css/main.css
@@ -86,6 +86,10 @@ hr { border: none; background: #e8e8e8; display: block; height: 1px; margin: 18p
 
 h1 a, h2 a, h3 a, h4 a, h5 a, h6 a { text-decoration: none; }
 
+pre, tt, code {
+	font-family: Consolas, ‘Andale Mono WT’, ‘Andale Mono’, ‘Lucida Console’, ‘Lucida Sans Typewriter’, ‘DejaVu Sans Mono’, ‘Bitstream Vera Sans Mono’, Monaco, ‘Courier New’, monospace;
+}
+
 pre, tt { 
 	color: #fafafa;
 	background: #333;
@@ -124,7 +128,7 @@ pre {
 
 pre code {
 	background: none;
-	white-space: pre;	
+	white-space: pre;
 	overflow: hidden;
 }
 
@@ -134,7 +138,6 @@ pre code {
 
 .duckduckhack-docs pre code {
 	font-size: 12px;
-	font-family: Consolas, ‘Andale Mono WT’, ‘Andale Mono’, ‘Lucida Console’, ‘Lucida Sans Typewriter’, ‘DejaVu Sans Mono’, ‘Bitstream Vera Sans Mono’, Monaco, ‘Courier New’, monospace;
 }
 
 /* For syntax highlighting in code blocks */

--- a/share/css/main.css
+++ b/share/css/main.css
@@ -128,6 +128,15 @@ pre code {
 	overflow: hidden;
 }
 
+.duckduckhack-docs pre {
+	padding: 0;
+}
+
+.duckduckhack-docs pre code {
+	font-size: 12px;
+	font-family: Consolas, ‘Andale Mono WT’, ‘Andale Mono’, ‘Lucida Console’, ‘Lucida Sans Typewriter’, ‘DejaVu Sans Mono’, ‘Bitstream Vera Sans Mono’, Monaco, ‘Courier New’, monospace;
+}
+
 /* For syntax highlighting in code blocks */
 code > .synComment { color: lightblue; }
 code > .synConstant { color: lightgreen; }


### PR DESCRIPTION
- Reduce font-size to 12px from 14 for narrower code blocks
- Switch to better, cross-platform font-stack
- changes only affect docs pages, based on duckduckhack-docs class on
  <body>

This coincides with the changes to Community-Platform which adds syntax highlighting to the DuckDuckHack docs: https://github.com/duckduckgo/community-platform/pull/330

//cc @russellholt @sdougbrown 
